### PR TITLE
Fix getenv for empty environment

### DIFF
--- a/src/libstd/sys/hermit/os.rs
+++ b/src/libstd/sys/hermit/os.rs
@@ -140,8 +140,12 @@ pub fn env() -> Env {
 
 pub fn getenv(k: &OsStr) -> io::Result<Option<OsString>> {
     unsafe {
-        match ENV.as_ref().unwrap().lock().unwrap().get_mut(k) {
-            Some(value) => Ok(Some(value.clone())),
+        let env_ref = ENV.as_ref();
+        match env_ref {
+            Some(env_ref_unwrapped) => match env_ref_unwrapped.lock().unwrap().get_mut(k) {
+                Some(value) => Ok(Some(value.clone())),
+                None => Ok(None),
+            },
             None => Ok(None),
         }
     }


### PR DESCRIPTION
I ran into some problems using uhyve and hermit. In particular the initilzation function for the environment seems to not be called, which causes the first unwrap in getenv to fail. 
What is your stance on this? Do you just require that the initialization function must always be called, or is the approach of adding additional guards for every function trying to modify ENV okay?
