### PR TITLE
Unbox mutexes, condvars and rwlocks on hermit

### DIFF
--- a/library/std/src/sys/hermit/condvar.rs
+++ b/library/std/src/sys/hermit/condvar.rs
@@ -14,7 +14,7 @@ pub struct Condvar {
     sem2: *const c_void,
 }
 
-pub type MovableCondvar = Box<Condvar>;
+pub type MovableCondvar = Condvar;
 
 unsafe impl Send for Condvar {}
 unsafe impl Sync for Condvar {}

--- a/library/std/src/sys/hermit/mutex.rs
+++ b/library/std/src/sys/hermit/mutex.rs
@@ -156,7 +156,7 @@ pub struct Mutex {
     inner: Spinlock<MutexInner>,
 }
 
-pub type MovableMutex = Box<Mutex>;
+pub type MovableMutex = Mutex;
 
 unsafe impl Send for Mutex {}
 unsafe impl Sync for Mutex {}

--- a/library/std/src/sys/hermit/rwlock.rs
+++ b/library/std/src/sys/hermit/rwlock.rs
@@ -8,7 +8,7 @@ pub struct RWLock {
     state: UnsafeCell<State>,
 }
 
-pub type MovableRWLock = Box<RWLock>;
+pub type MovableRWLock = RWLock;
 
 enum State {
     Unlocked,


### PR DESCRIPTION
See https://github.com/rust-lang/rust/pull/77380.

On hermit mutexes and condvars are movable.

What do you think, @stlankes?