### PR TITLE
Hermit: Fix unused-variables warning

### DIFF
--- a/library/std/src/sys/hermit/net.rs
+++ b/library/std/src/sys/hermit/net.rs
@@ -182,7 +182,7 @@ impl TcpStream {
         Ok(self.clone())
     }
 
-    pub fn set_linger(&self, linger: Option<Duration>) -> io::Result<()> {
+    pub fn set_linger(&self, _: Option<Duration>) -> io::Result<()> {
         unsupported()
     }
 


### PR DESCRIPTION
Introduced by 3b6777f1ab7952c058d69be15805a06a8ce0f1da

Without this `x86_64-unknown-hermit` fails to build.